### PR TITLE
Feature/integrate vscode extension

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -34,3 +34,5 @@
 **/test/automation/out/**
 **/typings/**
 !.vscode
+# STENCILA: ignore our vscode extension
+**/extensions/stencila-editor/**

--- a/.eslintignore
+++ b/.eslintignore
@@ -34,5 +34,3 @@
 **/test/automation/out/**
 **/typings/**
 !.vscode
-# STENCILA: ignore our vscode extension
-**/extensions/stencila-editor/**

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ vscode.db
 product.overrides.json
 *.snap.actual
 .vscode-test
+# STENCILA: exclude stencila extensions
+/extensions/stencila*

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,5 @@ vscode.db
 product.overrides.json
 *.snap.actual
 .vscode-test
-# STENCILA: exclude stencila extensions
-/extensions/stencila*
+# STENCILA: exclude stencila repo (added when cloning)
+/stencila

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ product.overrides.json
 .vscode-test
 # STENCILA: exclude stencila repo (added when cloning)
 /stencila
+/extensions/stencila*

--- a/product.json
+++ b/product.json
@@ -80,5 +80,9 @@
 				"publisherDisplayName": "Microsoft"
 			}
 		}
-	]
+	],
+	"extensionAllowedProposedApi": ["stencila.extension.editor"],
+	"workbench": {
+		"colorTheme": "stencila.extension.editor.StencilaLight"
+	}
 }

--- a/product.json
+++ b/product.json
@@ -83,6 +83,7 @@
 	],
 	"extensionAllowedProposedApi": ["stencila.extension.editor"],
 	"workbench": {
-		"colorTheme": "stencila.extension.editor.StencilaLight"
+		"colorTheme": "stencila.extension.editor.StencilaLight",
+		"iconTheme": "stencila.extension.editor.StencilaIcons"
 	}
 }

--- a/scripts/integrate-stencila-extension.sh
+++ b/scripts/integrate-stencila-extension.sh
@@ -33,14 +33,17 @@ else
 fi
 
 # cleanup existing extension
-rm -rf ${EXTENSION_PATH}
+rm -rf ${EXTENSION_PATH} ${EXTENSION_REPO_NAME}
 
 # clone stencila repo
-git clone ${EXTENSION_REPO} ${EXTENSION_REPO_NAME}
+git clone --depth 1 -- ${EXTENSION_REPO} ${EXTENSION_REPO_NAME}
 # move stencila vscode directory to extensions
 mv ${EXTENSION_REPO_NAME}/${EXTENSION_REPO_FOLDER_NAME} ${EXTENSION_PATH}
 
 # compile extension
 npm --prefix ${EXTENSION_PATH} i && npm --prefix ${EXTENSION_PATH} run compile
+
+# clean up
+rm -rf ${EXTENSION_REPO_NAME}
 
 exit 0

--- a/scripts/integrate-stencila-extension.sh
+++ b/scripts/integrate-stencila-extension.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+EXTENSION_REPO=git@github.com:stencila/vscode-extension.git
+EXTENSION_PATH=extensions/stencila-editor
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+	realpath() { [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"; }
+	ROOT=$(dirname "$(dirname "$(realpath "$0")")")
+else
+	ROOT=$(dirname "$(dirname "$(readlink -f $0)")")
+fi
+
+# clone extension
+rm -rf ${EXTENSION_PATH} && git clone ${EXTENSION_REPO} ${EXTENSION_PATH}
+
+# compile extension
+npm --prefix ${EXTENSION_PATH} i && npm --prefix ${EXTENSION_PATH} run compile
+
+exit 0

--- a/scripts/integrate-stencila-extension.sh
+++ b/scripts/integrate-stencila-extension.sh
@@ -1,8 +1,28 @@
 #!/usr/bin/env bash
 
+#
+# Integrate Stencila Extension:
+# -----------------------------
+# This script clones and installs the stencila/vscode extension into the code
+# base from the stencila repo. It performs the following tasks:
+#
+# 1. Clone the stencila/stencila repo
+# 2. Move the vscode folder from the repo into the extensions directory
+# 3. Installs the rewuires npm packages
+# 4. Compiles the extension
+# 5. Removes the cloned repo
+#
+# NOTE: It is assumed that the git user running this command has access to the
+# stencila/stencila repo.
+#
+# This extension is referenced in product.json. Remove from there if you'd like
+# to disable this extension.
+
 set -e
 
-EXTENSION_REPO=git@github.com:stencila/vscode-extension.git
+EXTENSION_REPO=git@github.com:stencila/stencila.git
+EXTENSION_REPO_NAME=stencila
+EXTENSION_REPO_FOLDER_NAME=vscode
 EXTENSION_PATH=extensions/stencila-editor
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -12,8 +32,13 @@ else
 	ROOT=$(dirname "$(dirname "$(readlink -f $0)")")
 fi
 
-# clone extension
-rm -rf ${EXTENSION_PATH} && git clone ${EXTENSION_REPO} ${EXTENSION_PATH}
+# cleanup existing extension
+rm -rf ${EXTENSION_PATH}
+
+# clone stencila repo
+git clone ${EXTENSION_REPO} ${EXTENSION_REPO_NAME}
+# move stencila vscode directory to extensions
+mv ${EXTENSION_REPO_NAME}/${EXTENSION_REPO_FOLDER_NAME} ${EXTENSION_PATH}
 
 # compile extension
 npm --prefix ${EXTENSION_PATH} i && npm --prefix ${EXTENSION_PATH} run compile

--- a/src/vs/platform/product/common/product.ts
+++ b/src/vs/platform/product/common/product.ts
@@ -30,8 +30,8 @@ else if (globalThis._VSCODE_PRODUCT_JSON && globalThis._VSCODE_PACKAGE_JSON) {
 	// Running out of sources
 	if (env['VSCODE_DEV']) {
 		Object.assign(product, {
-			nameShort: `${product.nameShort} Dev`,
-			nameLong: `${product.nameLong}-dev`,
+			nameShort: `${product.nameShort}`,
+			nameLong: `${product.nameLong}`,
 			dataFolderName: `${product.dataFolderName}`,
 			serverDataFolderName: product.serverDataFolderName ? `${product.serverDataFolderName}-dev` : undefined
 		});


### PR DESCRIPTION
**Description**

This PR includes a new script `integrate-stencila-extension.sh` which allows us to download, install & compile the stencila-editor vscode extension.

The extension is then set as an extension in the `product.json` file. The extensions' theme is applied as the default theme for the writer:

product.json:

```json
{
  ...
  "extensionAllowedProposedApi": ["stencila.extension.editor"],
  "workbench": {
    "colorTheme": "stencila.extension.editor.StencilaLight",
    "iconTheme": "stencila.extension.editor.StencilaIcons"
  }
  ...
}
```

To run:

```bash
./scripts/integrate-stencila-extension.sh
```

This _should_ checkout the `stencila/stencila` repo, copy the files to the extension, install dependencies & compile the extension ready for use. It does require that the git user running the script has access to the `stencila/stencila` repo.

> [!WARNING]
> I had intended for the extension directory `stencila-editor` to be included in the repo, so that once it gets updated, it's available for all. Currently however, the precommit script (`build/hygeine.sh`) has issues with formatting on the majority of files within the extension. Until that is resolved, I will ignore from the repo.